### PR TITLE
Update to Iris version 12

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"github.com/Sirupsen/logrus"
 	redigo "github.com/garyburd/redigo/redis"
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
@@ -10,6 +9,7 @@ import (
 	"github.com/puper/ppgo/components/log"
 	"github.com/puper/ppgo/components/redis"
 	"github.com/puper/ppgo/engine"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/components/iris/component.go
+++ b/components/iris/component.go
@@ -3,7 +3,7 @@ package iris
 import (
 	"context"
 
-	"github.com/kataras/iris"
+	"github.com/kataras/iris/v12"
 
 	"github.com/puper/ppgo/engine"
 	"github.com/puper/ppgo/helpers"

--- a/components/iris/iris.go
+++ b/components/iris/iris.go
@@ -1,7 +1,7 @@
 package iris
 
 import (
-	"github.com/kataras/iris"
+	"github.com/kataras/iris/v12"
 )
 
 type Config struct {

--- a/components/log/log.go
+++ b/components/log/log.go
@@ -1,7 +1,7 @@
 package log
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type Log struct {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -3,8 +3,8 @@ package errors
 import (
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/puper/tracerr"
+	"github.com/sirupsen/logrus"
 )
 
 var defaultLogger = logrus.New()

--- a/v2/components/irisapp/irisapp.go
+++ b/v2/components/irisapp/irisapp.go
@@ -3,7 +3,7 @@ package irisapp
 import (
 	"context"
 
-	"github.com/kataras/iris"
+	"github.com/kataras/iris/v12"
 )
 
 type Application struct {

--- a/v2/components/log/log.go
+++ b/v2/components/log/log.go
@@ -1,7 +1,7 @@
 package log
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type Log struct {

--- a/v2/errors/errors.go
+++ b/v2/errors/errors.go
@@ -3,8 +3,8 @@ package errors
 import (
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/puper/tracerr"
+	"github.com/sirupsen/logrus"
 )
 
 var defaultLogger = logrus.New()

--- a/v2/examples/go.mod
+++ b/v2/examples/go.mod
@@ -1,0 +1,5 @@
+module ppgo/v2/examples
+
+go 1.13
+
+require github.com/kataras/iris/v12 v12.0.1

--- a/v2/examples/main.go
+++ b/v2/examples/main.go
@@ -6,7 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/kataras/iris"
+	"github.com/kataras/iris/v12"
 
 	"github.com/puper/ppgo/v2/components/db"
 	"github.com/puper/ppgo/v2/components/irisapp"


### PR DESCRIPTION
Hello @puper and @penguinn ,

[Iris](https://iris-go.com) has been updated to version 12.0.1 which requires a new semantic import path. Read [here](https://github.com/kataras/iris/releases/tag/v12.0.1) for more. This PR updates the code base to be compatible with Iris v12.0.1. 

Thanks,
Gerasimos Maropoulos. Author of the Iris Web Framework.